### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a CouchDB connector"
 og:title: "Set up a CouchDB connector"
-description: "C1 provides identity governance and just-in-time provisioning for Apache CouchDB. Integrate your CouchDB instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Apache CouchDB. Integrate your CouchDB instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for CouchDB. Integrate your CouchDB instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for CouchDB. Integrate your CouchDB instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "CouchDB"
 ---
 
@@ -33,7 +33,7 @@ Each setup method requires you to pass in credentials generated in CouchDB. Gath
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the CouchDB connector
 
@@ -87,7 +87,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your CouchDB connector is now pulling access data into C1.
+**Done.** Your CouchDB connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -203,7 +203,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your CouchDB connector is now pulling access data into C1.
+**Done.** Your CouchDB connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines