### PR TITLE
fix: mark password as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		"password",
 		field.WithDescription("The password of the CouchDB admin account"),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	),
 	field.StringField(
 		"instance-url",


### PR DESCRIPTION
The `password` config field holds the CouchDB admin account password but was defined as a plain `field.StringField` with no `field.WithIsSecret(true)`, so it was not marked secret. This adds `WithIsSecret(true)`. The `username` and `instance-url` fields are not credentials and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
