### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/databases.go
+++ b/pkg/connector/databases.go
@@ -50,15 +50,14 @@ func parseIntoDatabaseResource(database string) (*v2.Resource, error) {
 		"database_name": database,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		database,
 		databaseResourceType,
 		database,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},
 			&v2.ChildResourceType{ResourceTypeId: roleResourceType.Id},

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -117,15 +117,14 @@ func parseIntoRoleResource(user client.User, parentResourceID *v2.ResourceId) (*
 		"database": user.Database,
 	}
 
-	roleTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraits := []rs.RoleTraitOption{}
 
 	return rs.NewRoleResource(
 		displayName,
 		roleResourceType,
 		id,
 		roleTraits,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -109,16 +109,15 @@ func parseIntoUserResource(user client.User, parentResourceID *v2.ResourceId) (*
 		"database": user.Database,
 	}
 
-	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
-	}
+	userTraits := []rs.UserTraitOption{}
 
 	return rs.NewUserResource(
 		displayName,
 		userResourceType,
 		id,
 		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
